### PR TITLE
Update _footer.slim

### DIFF
--- a/includes/_footer.slim
+++ b/includes/_footer.slim
@@ -18,15 +18,15 @@ footer.page-footer
         h4 Lovingly sponsored by
         p.sponsors
           | <a href="http://artsy.net">Artsy</a>,
-          | <a href="http://discontinuity.eu"> Discontinuity</a>,
-          | <a href="http://www.fngtps.com"> Fingertips</a>,
-          | <a href="https://www.heroku.com"> Heroku</a>,
-          | <a href="http://www.rubymotion.com"> RubyMotion</a>,
-          | <a href="https://www.sauspiel.de"> Sauspiel</a>,
-          | <a href="https://www.slack.com"> Slack</a>,
-          | <a href="https://www.soundcloud.com"> SoundCloud</a>,
-          | <a href="https://www.stripe.com"> Stripe</a> and
-          | <a href="http://www.technologyastronauts.ch"> Technology&nbsp;Astronauts</a>.
+          |  <a href="http://discontinuity.eu">Discontinuity</a>,
+          |  <a href="http://www.fngtps.com">Fingertips</a>,
+          |  <a href="https://www.heroku.com">Heroku</a>,
+          |  <a href="http://www.rubymotion.com">RubyMotion</a>,
+          |  <a href="https://www.sauspiel.de">Sauspiel</a>,
+          |  <a href="https://www.slack.com">Slack</a>,
+          |  <a href="https://www.soundcloud.com">SoundCloud</a>,
+          |  <a href="https://www.stripe.com">Stripe</a> and
+          |  <a href="http://www.technologyastronauts.ch">Technology&nbsp;Astronauts</a>.
 
 footer.footer-links
   section.container


### PR DESCRIPTION
This prevents the line under the links on hover from covering the leading space, too.

Before:
![screen shot 2015-02-03 at 14 27 56](https://cloud.githubusercontent.com/assets/212465/6020879/53f2ce84-abb1-11e4-9b81-479638c7ea4c.png)
After:
![screen shot 2015-02-03 at 14 27 38](https://cloud.githubusercontent.com/assets/212465/6020880/589483ba-abb1-11e4-9812-32fe2de695e8.png)
