### PR TITLE
Use em for header line heights instead of pixel

### DIFF
--- a/sass/main.scss.erb
+++ b/sass/main.scss.erb
@@ -24,34 +24,34 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 {
   font-size: 48px;
-  line-height: 52px;
+  line-height: 1.083em;
 }
 
 h2 {
   font-size: 40px;
-  line-height: 52px;
+  line-height: 1.3em;
 }
 
 h3 {
   color: $cocoapods-highlight-color;
   font-size: 32px;
-  line-height: 41px;
+  line-height: 1.28125em;
   font-weight:normal;
 }
 
 h4 {
   font-size: 24px;
-  line-height: 32px;
+  line-height: 1.333em;
 }
 
 h5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 1.333em;
 }
 
 h6 {
   font-size: 14px;
-  line-height: 19px;
+  line-height: 1.357em;
 }
 
 aside {


### PR DESCRIPTION
This fixes visual glitches that occur when the
font size is changed to a higher pixel value, for
example the 404 page on cocoadocs.

See: https://imgur.com/6MzGHO1

This change should not cause any visual regression for existing headlines since the em values were calculated using the previous pixel values

cc @orta 

